### PR TITLE
Update pam_access.c

### DIFF
--- a/modules/pam_access/pam_access.c
+++ b/modules/pam_access/pam_access.c
@@ -727,7 +727,7 @@ network_netmask_match (pam_handle_t *pamh,
 	  { /* netmask as integre value */
 	    char *endptr = NULL;
 	    netmask = strtol(netmask_ptr, &endptr, 0);
-	    if ((endptr == NULL) || (*endptr != '\0'))
+	    if ((endptr == netmask_ptr) || (*endptr != '\0'))
 		{ /* invalid netmask value */
 		  return NO;
 		}


### PR DESCRIPTION
The strtol/strtoll/strtoul family of functions to not set endptr to NULL but rather "If  endptr is not NULL, strtol() stores the address of the first invalid character in *endptr.  If there were no digits at all, strtol() stores the original value of nptr in *endptr (and returns 0)."